### PR TITLE
fix: login error

### DIFF
--- a/webServer/package-lock.json
+++ b/webServer/package-lock.json
@@ -643,6 +643,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
       "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2369,6 +2370,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/webServer/src/controller/AuthController.ts
+++ b/webServer/src/controller/AuthController.ts
@@ -10,7 +10,7 @@ export class AuthController  {
         this.authService = new AuthService()
     }
 
-    async login(req: Request, res: Response) {
+    login = async (req: Request, res: Response) => {
         try{
             const { email, password } = req.body
 
@@ -24,7 +24,7 @@ export class AuthController  {
             })
             }
             return res.status(500).json({
-                error: "Internal server error"
+                error: error.message || 'Internal Server Error'
             })
         }
     }

--- a/webServer/src/server.ts
+++ b/webServer/src/server.ts
@@ -7,7 +7,7 @@ dotenv.config({quiet:true});
 const app = express();
 
 app.use(express.json());
-app.use('/auth', router)
+app.use('/', router)
 
 const PORT = process.env.PORT;
 

--- a/webServer/src/service/AuthService.ts
+++ b/webServer/src/service/AuthService.ts
@@ -2,7 +2,7 @@ import { AppError } from "@/interfaces/errors/AppError.ts";
 import { UserPayload } from "../interfaces/user.interface.ts";
 import { createToken as signJwtToken } from "../lib/jwt.ts";
 import * as bcrypt from 'bcrypt'
-import knex from "knex";
+import knex from "@/database/knex.ts";
 
 export class AuthService  {
 


### PR DESCRIPTION
Solucionamos um importante erro no método do login (em **authService**), e consertamos a rota /auth/login:

- Mudamos o import do knex (antes estava importando o objeto da lib, agora está importando a **instance**  direto do nosso '@/database/knex.ts';
- Sem essa mudança, o knex estava carregando a config padrão (precisa do sqlite3), acusando esse erro: 
```
  Knex: run
  $ npm install sqlite3 --save
  Cannot find module 'sqlite3'
  Require stack:
  - /home/capivas/Desktop/labsec/webServer/node_modules/knex/lib/dialects/sqlite3/index.js
  - /home/capivas/Desktop/labsec/webServer/node_modules/knex/lib/dialects/index.js
  - /home/capivas/Desktop/labsec/webServer/node_modules/knex/lib/knex-builder/internal/config-resolver.js
  - /home/capivas/Desktop/labsec/webServer/node_modules/knex/lib/knex-builder/Knex.js
  - /home/capivas/Desktop/labsec/webServer/node_modules/knex/lib/index.js
  - /home/capivas/Desktop/labsec/webServer/node_modules/knex/knex.js
  Error: Cannot find module 'sqlite3'
  Require stack:
```
- O @GuilhermeAndradeTaveira realizou o teste de login, após as mudanças, com um usuário de seed, e o método retornou tanto o token jwt quanto o usuário
- Com todas as mudanças funcionando, encerro a descrição da PR.
